### PR TITLE
83324_noti_for_apply

### DIFF
--- a/app/assets/stylesheets/enterprise.scss
+++ b/app/assets/stylesheets/enterprise.scss
@@ -23,3 +23,40 @@
 .sidebar-text {
   color: $textDarkBlue !important;
 }
+
+.notifications-dropdown {
+  width: 500px;
+  max-height: 300px;
+  position: relative;
+}
+
+.noti-unread {
+  position: absolute;
+  top: 0;
+  right: 0;
+  transform: translate(50%, -50%);
+  background-color: red;
+  color: white;
+  border-radius: 50% !important;
+  padding: 0.25em 0.5em;
+  height: 27px;
+  width: 27px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75em;
+  border: 2px solid #0d6efd;
+}
+
+.notifications-dropdown-menu {
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+.notifications-dropdown-menu:last-child {
+  border-radius: 0 0 0.375rem 0.375rem;
+}
+
+.noti-text {
+  white-space: pre-line;
+}

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -41,6 +41,7 @@ class ApplicationsController < ApplicationController
 
   def save_application
     if @application.save
+      create_notification_for_enterprise(@application)
       flash[:success] = t "flash.application.success"
       redirect_to job_path(id: @application.job.id)
     else
@@ -78,5 +79,18 @@ class ApplicationsController < ApplicationController
 
   def filtered_application_params
     application_params.except(:use_existing_cv)
+  end
+
+  def create_notification_for_enterprise application
+    enterprise_users = application.job.company.users
+    enterprise_users.each do |user|
+      Notification.create!(
+        user:,
+        title: "notifications.new_application",
+        content: "notifications.new_application_content",
+        params: {user: current_user.full_name, job: application.job.title},
+        is_read: false
+      )
+    end
   end
 end

--- a/app/controllers/enterprise/applications_controller.rb
+++ b/app/controllers/enterprise/applications_controller.rb
@@ -1,5 +1,6 @@
 class Enterprise::ApplicationsController < ApplicationController
   layout "enterprise"
+  include NotificationsHelper
   before_action :load_application, only: [:show, :update_status]
 
   def index
@@ -13,8 +14,7 @@ class Enterprise::ApplicationsController < ApplicationController
 
   def update_status
     if @application.update(status: params[:status])
-      flash[:success] = t("flash.application.update_success")
-      redirect_to enterprise_application_path(@application)
+      handle_update_success(@application, params[:status])
     else
       flash[:danger] = t("flash.application.update_error")
       render :show
@@ -31,5 +31,16 @@ class Enterprise::ApplicationsController < ApplicationController
 
     flash[:danger] = t "enterprise.applications.not_found"
     redirect_to enterprise_applications_path
+  end
+
+  def handle_update_success application, status
+    create_notification_for_applicant(
+      application,
+      "notifications.application_status_updated",
+      "notifications.application_status_updated_content",
+      {job: application.job.title, status: status.capitalize}
+    )
+    flash[:success] = t("flash.application.update_success")
+    redirect_to enterprise_application_path(application)
   end
 end

--- a/app/controllers/enterprise/interview_processes_controller.rb
+++ b/app/controllers/enterprise/interview_processes_controller.rb
@@ -1,10 +1,17 @@
 class Enterprise::InterviewProcessesController < ApplicationController
+  include NotificationsHelper
   before_action :set_application
 
   def create
     @interview_process = @application.interview_processes
                                      .build(interview_process_params)
     if @interview_process.save
+      create_notification_for_applicant(
+        @application,
+        "notifications.interview_process_created",
+        "notifications.interview_process_created_content",
+        {job: @application.job.title}
+      )
       flash[:success] = t("flash.interview.create_success")
     else
       flash[:danger] = t("flash.interview.create_error")
@@ -15,7 +22,7 @@ class Enterprise::InterviewProcessesController < ApplicationController
   def update
     @interview_process = @application.interview_processes.find(params[:id])
     if @interview_process.update(interview_process_params)
-      flash[:success] = t("flash.interview.update_success")
+      handle_update_success @application
     else
       flash[:danger] = t("flash.interview.update_error")
     end
@@ -25,6 +32,12 @@ class Enterprise::InterviewProcessesController < ApplicationController
   def destroy
     @interview_process = @application.interview_processes.find(params[:id])
     if @interview_process.destroy
+      create_notification_for_applicant(
+        @application,
+        "notifications.interview_process_deleted",
+        "notifications.interview_process_deleted_content",
+        {job: @application.job.title}
+      )
       flash[:success] = t("flash.interview.delete_success")
     else
       flash[:danger] = t("flash.interview.delete_error")
@@ -44,5 +57,15 @@ class Enterprise::InterviewProcessesController < ApplicationController
       :stage_number, :stage_type, :interview_time, :interview_location,
       :interview_type, :interviewer_name, :status, :feedback, :rating, :result
     )
+  end
+
+  def handle_update_success application
+    create_notification_for_applicant(
+      application,
+      "notifications.interview_process_updated",
+      "notifications.interview_process_updated_content",
+      {job: application.job.title}
+    )
+    flash[:success] = t("flash.interview.update_success")
   end
 end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,0 +1,12 @@
+class NotificationsController < ApplicationController
+  def mark_all_as_read
+    current_user.notifications.update_all(is_read: true)
+    redirect_to request.referer || root_path
+  end
+
+  def mark_as_read
+    @notification = current_user.notifications.find(params[:id])
+    @notification.update(is_read: true)
+    redirect_to request.referer || root_path
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,4 +8,8 @@ module ApplicationHelper
   def active_link_to path
     "active text-light fw-bold bg-primary" if request.path == path
   end
+
+  def seen_background_color notification
+    "bg-light" if notification.is_read
+  end
 end

--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -1,0 +1,11 @@
+module NotificationsHelper
+  def create_notification_for_applicant application, title, content, params = {}
+    Notification.create(
+      user_id: application.user_id,
+      title:,
+      content:,
+      params:,
+      is_read: false
+    )
+  end
+end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -15,6 +15,10 @@ module SessionsHelper
     end
   end
 
+  def unread_notifications
+    current_user.notifications.unread.count
+  end
+
   def logged_in?
     current_user.present?
   end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,3 +1,10 @@
 class Notification < ApplicationRecord
   belongs_to :user
+
+  validates :title, presence: true
+  validates :content, presence: true
+
+  default_scope{order(created_at: :desc)}
+
+  scope :unread, ->{where(is_read: false)}
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,8 +2,9 @@ class User < ApplicationRecord
   has_one_attached :avatar
   has_secure_password
 
+  belongs_to :company, optional: true
+
   has_one :user_profile, dependent: :destroy
-  accepts_nested_attributes_for :user_profile, reject_if: :all_blank
   has_many :applications, dependent: :destroy
   has_many :applied_jobs, through: :applications, source: :job
   has_many :company_reviews, dependent: :destroy
@@ -11,9 +12,11 @@ class User < ApplicationRecord
   has_many :followed_companies, through: :company_followers, source: :company
   has_many :notifications, dependent: :destroy
   has_many :user_social_links, dependent: :destroy
+
   accepts_nested_attributes_for :user_social_links, allow_destroy: true
+  accepts_nested_attributes_for :user_profile, reject_if: :all_blank
+
   delegate :user_projects, to: :user_profile
-  belongs_to :company, optional: true
 
   enum role: {user: 0, business: 1, admin: 2}
 

--- a/app/views/enterprise/applications/index.html.erb
+++ b/app/views/enterprise/applications/index.html.erb
@@ -1,5 +1,4 @@
 <% provide :title, t("enterprise.applications.new_apply") %>
-<h1 class="text-center my-4"><%= t "enterprise.applications.newest_apply" %></h1>
 
 <div class="container">
   <div class="d-flex justify-content-between align-items-center mb-2">

--- a/app/views/enterprise/dashboard/index.html.erb
+++ b/app/views/enterprise/dashboard/index.html.erb
@@ -1,5 +1,4 @@
 <%= provide(:title, t("enterprise.scout.title")) %>
-<h2><%= t "enterprise.scout.title" %></h2>
 <div class="d-flex justify-content-between align-items-center mb-4">
   <%= form_with method: :get, url: enterprise_root_path do |f| %>
     <div class="d-flex">

--- a/app/views/enterprise/jobs/_form.html.erb
+++ b/app/views/enterprise/jobs/_form.html.erb
@@ -32,7 +32,7 @@
 
     <div class="col-md-6">
       <%= f.label :status, t("enterprise.recruitment.status"), class: "form-label" %>
-      <%= f.select :status, statuses_options, { prompt: "Select status" }, class: "form-select" %>
+      <%= f.select :status, status_options, { prompt: "Select status" }, class: "form-select" %>
     </div>
 
     <div data-controller="job-skills" data-job-skills-target="container" class="mb-3">

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -14,7 +14,8 @@
       <%= link_to t("header.for_employers"), enterprise_login_path %>
     <% end %>
     <% if logged_in? %>
-      <div class="dropdown header-username" id="header-dropdown">
+      <%= render "shared/notification" %>
+      <div class="dropdown header-username ms-3" id="header-dropdown">
         <div class="dropdown-toggle" data-toggle="dropdown">
           <%= current_user.full_name %>
           <b class="caret"></b>

--- a/app/views/layouts/enterprise.html.erb
+++ b/app/views/layouts/enterprise.html.erb
@@ -58,6 +58,12 @@
         <% flash.each do |message_type, message| %>
           <div class="alert alert-<%= message_type %>"><%= message %></div>
         <% end %>
+        <div class="d-flex justify-content-between w-100 mb-4">
+          <span class="fw-bold h1">
+            <%= yield(:title) %>
+          </span>
+          <%= render "shared/notification" %>
+        </div>
         <%= yield %>
       </div>
     </div>

--- a/app/views/shared/_notification.html.erb
+++ b/app/views/shared/_notification.html.erb
@@ -1,0 +1,36 @@
+<div class="dropdown notifications-dropdown">
+  <button class="btn btn-primary float-end" data-bs-toggle="dropdown" aria-expanded="false">
+    <i class="fa-solid fa-bell"></i>
+    <span class="noti-unread"><%= unread_notifications %></span>
+  </button>
+  <ul class="dropdown-menu notifications-dropdown-menu">
+    <li class="px-3 py-2 border-bottom border-dark position-sticky top-0 bg-light">
+      <span class="fw-bold fs-5"><%= t("notifications.notifications") %></span>
+    </li>
+    <% if current_user.notifications.any? %>
+      <% current_user.notifications.each do |notification| %>
+        <li class="dropdown-item py-2 border-bottom border-secondary-subtle <%= seen_background_color(notification) %>">
+          <div class="d-flex align-items-center w-100">
+            <% unless notification.is_read %>
+              <%= link_to mark_as_read_notification_path(id: notification.id), data: { turbo_method: :patch }, class: "text-decoration-none text-dark" do %>
+                <i class="fa-solid fa-circle-check"></i>
+              <% end %>
+            <% end %>
+            <div class="ms-2 d-flex justify-content-between align-items-center w-100">
+              <span class="fw-bold fs-5"><%= t(notification.title) %></span>
+              <span class="text-muted"><%= notification.created_at.strftime("%d/%m/%Y %H:%M") %></span>
+            </div>
+          </div>
+          <span class="text-muted noti-text"><%= t(notification.content, **(notification.params || {}).symbolize_keys) %></span>
+        </li>
+      <% end %>
+    <% else %>
+      <li class="dropdown-item text-center py-2 border-bottom border-secondary-subtle">
+        <span class="fs-5"><%= t("notifications.no_notification") %></span>
+      </li>
+    <% end %>
+    <li class="dropdown-item py-2 text-center position-sticky bottom-0 bg-light">
+      <%= link_to t("notifications.mark_all_as_read"), mark_all_as_read_notifications_path, data: { turbo_method: :patch }, class: "text-decoration-none text center text-dark" %>
+    </li>
+  </ul>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -265,3 +265,17 @@ en:
     login:
       admin_login: "Admin Login"
   status: "Status"
+  notifications:
+    new_application: "New Application"
+    new_application_content: "%{user} has applied for the job %{job}."
+    application_status_updated: "Application Status Updated"
+    application_status_updated_content: "Your application for %{job} has been updated to %{status}."
+    interview_process_deleted: "Interview Process Deleted"
+    interview_process_deleted_content: "Your interview process for %{job} has been deleted. Please check your application for more information."
+    interview_process_updated: "Interview Process Updated"
+    interview_process_updated_content: "Your interview process for %{job} has been updated. Please check your application for more information."
+    interview_process_created: "New Interview Process"
+    interview_process_created_content: "You have a new interview process for %{job}. Please check your application for more information."
+    no_notification: "No notifications"
+    mark_all_as_read: "Mark All As read"
+    notifications: "Notifications"

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -265,6 +265,20 @@ vi:
     login:
       admin_login: "Admin Login"
   status: "Status"
+  notifications:
+    new_application: "Ứng tuyển mới"
+    new_application_content: "%{user} đã ứng tuyển cho công việc %{job}."
+    application_status_updated: "Trạng thái ứng tuyển đã được cập nhật"
+    application_status_updated_content: "Ứng tuyển của bạn cho công việc %{job} đã được cập nhật thành %{status}."
+    interview_process_deleted: "Vòng phỏng vấn đã được xóa"
+    interview_process_deleted_content: "Vòng phỏng vấn của bạn cho công việc %{job} đã được xóa. Vui lòng kiểm tra ứng tuyển của bạn để biết thêm chi tiết."
+    interview_process_updated: "Vòng phỏng vấn đã được cập nhật"
+    interview_process_updated_content: "Vòng phỏng vấn của bạn cho công việc %{job} đã được cập nhật. Vui lòng kiểm tra ứng tuyển của bạn để biết thêm chi tiết."
+    interview_process_created: "Vòng phỏng vấn mới"
+    interview_process_created_content: "Bạn có một vòng phỏng vấn mới cho công việc %{job}. Vui lòng kiểm tra ứng tuyển của bạn để biết thêm chi tiết."
+    no_notification: "Không có thông báo"
+    mark_all_as_read: "Đánh dấu tất cả là đã đọc"
+    notifications: "Thông báo"
   datetime:
     distance_in_words:
       less_than_x_seconds:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,15 @@ Rails.application.routes.draw do
       resources :user_social_links
     end
     resources :applications, only: %i(create show update)
+    resources :notifications, only: [] do
+      member do
+        patch :mark_as_read
+      end
+      collection do
+        patch :mark_all_as_read
+      end
+    end
+
     get "home/index"
     root "home#index"
     get "/login", to: "sessions#new"

--- a/db/migrate/20250108153239_add_params_to_notifications.rb
+++ b/db/migrate/20250108153239_add_params_to_notifications.rb
@@ -1,0 +1,5 @@
+class AddParamsToNotifications < ActiveRecord::Migration[7.0]
+  def change
+    add_column :notifications, :params, :json
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_12_17_081512) do
+ActiveRecord::Schema[7.0].define(version: 2025_01_08_153239) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -130,6 +130,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_12_17_081512) do
     t.boolean "is_read"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.json "params"
     t.index ["created_at"], name: "index_notifications_on_created_at"
     t.index ["is_read"], name: "index_notifications_on_is_read"
     t.index ["user_id"], name: "index_notifications_on_user_id"


### PR DESCRIPTION
## Related Tickets
- [#83324](https://edu-redmine.sun-asterisk.vn/issues/83324)

## WHAT (optional)
- Tạo notification cho cả 2 role. hiện tại chỉ mới có thông báo khi có 1 tác động đến 1 apply mới có thông báo
## HOW
- I edit js file, inject not_vary_normal items in calculate function.

## WHY (optional)
- Because in previous version - number just depends on `normal` items. But in new version, we have `state` and `confirm_state` depends on both `normal` + `not_normal` items.

## Evidence (Screenshot or Video)
Noti của role user khi doanh nghiệp có thay đổi mới đến cái apply của user:
![image](https://github.com/user-attachments/assets/3c66e8d9-72fd-483f-abdd-b05059240629)
bg-color xám là đã seen. Với tin nhắn chưa seen có thể tick vào vào dấu tick để đánh dấu đã là đã xem.
![image](https://github.com/user-attachments/assets/880f7901-7538-4b00-9514-09514a235571)
Role enterprise có thông báo khi ng dùng apply 1 job thuộc về công ty. Bất kì người tuyển dụng nào của công ty cũng nhận được thông báo